### PR TITLE
fix two compiling errors

### DIFF
--- a/coroutine/Coroutine.h
+++ b/coroutine/Coroutine.h
@@ -92,7 +92,7 @@ private:
     State state_;
     AnyPointer yieldValue_;
 
-    typedef ucontext HANDLE;
+    typedef ucontext_t HANDLE;
 
     static const std::size_t kDefaultStackSize = 8 * 1024;
     std::vector<char> stack_;

--- a/util/Logger.cc
+++ b/util/Logger.cc
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <functional>
 
 #include "TimeUtil.h"
 #include "Logger.h"


### PR DESCRIPTION
One leak \<functional\> head file. Another is `ucontext` to `uncontext_t`.
The third error appears in delegate file. I didn't fix and just delete related files to let compile pass.
delegate file error output is that:
```c++
In file included from /usr/include/c++/8.2.1/functional:59,
                 from /home/canftin/2019/ananas/util/Delegate.h:4,
                 from /home/canftin/2019/ananas/unittest/DelegateTest.cc:3:
/usr/include/c++/8.2.1/bits/std_function.h: In instantiation of ‘_Functor* std::function<_Res(_ArgTypes ...)>::target() [with _Functor = void(int&); _Res = void; _ArgTypes = {int&}]’:
/home/canftin/2019/ananas/util/Delegate.h:96:29:   required from ‘void ananas::Delegate<void(Args ...)>::disconnect(F&&) [with F = void (&)(int&); Args = {int&}]’
/home/canftin/2019/ananas/util/Delegate.h:69:9:   required from ‘ananas::Delegate<void(Args ...)>::Self& ananas::Delegate<void(Args ...)>::operator-=(F&&) [with F = void (&)(int&); Args = {int&}; ananas::Delegate<void(Args ...)>::Self = ananas::Delegate<void(int&)>]’
/home/canftin/2019/ananas/unittest/DelegateTest.cc:17:11:   required from here
/usr/include/c++/8.2.1/bits/std_function.h:714:9: error: invalid use of const_cast with type ‘void (*)(int&)’, which is a pointer or reference to a function type
  return const_cast<_Functor*>(__func);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/8.2.1/bits/std_function.h: In instantiation of ‘_Functor* std::function<_Res(_ArgTypes ...)>::target() [with _Functor = void(int); _Res = void; _ArgTypes = {int}]’:
/home/canftin/2019/ananas/util/Delegate.h:96:29:   required from ‘void ananas::Delegate<void(Args ...)>::disconnect(F&&) [with F = void (&)(int); Args = {int}]’
/home/canftin/2019/ananas/util/Delegate.h:69:9:   required from ‘ananas::Delegate<void(Args ...)>::Self& ananas::Delegate<void(Args ...)>::operator-=(F&&) [with F = void (&)(int); Args = {int}; ananas::Delegate<void(Args ...)>::Self = ananas::Delegate<void(int)>]’
/home/canftin/2019/ananas/unittest/DelegateTest.cc:64:11:   required from here
/usr/include/c++/8.2.1/bits/std_function.h:714:9: error: invalid use of const_cast with type ‘void (*)(int)’, which is a pointer or reference to a function type

```