### PR TITLE
[pipe] make pipe Read/Write NonBlock

### DIFF
--- a/net/PipeChannel.cc
+++ b/net/PipeChannel.cc
@@ -1,5 +1,6 @@
 #include <unistd.h>
 #include <cassert>
+#include <fcntl.h>
 
 #include "PipeChannel.h"
 
@@ -13,6 +14,8 @@ PipeChannel::PipeChannel() {
     assert (ret == 0);
     readFd_ = fd[0];
     writeFd_ = fd[1];
+    SetPipeNonBlock(readFd_);
+    SetPipeNonBlock(writeFd_);
 }
 
 PipeChannel::~PipeChannel() {
@@ -42,6 +45,16 @@ bool PipeChannel::Notify() {
     char ch = 0;
     auto n = ::write(writeFd_, &ch, sizeof ch);
     return n == 1;
+}
+
+void SetPipeNonBlock(int pipeFd, bool nonBlock) {
+    int flag = ::fcntl(pipeFd, F_GETFL, 0);
+    assert(flag >= 0 && "Pipe Non Block failed");
+
+    if (nonBlock) 
+        flag = ::fcntl(pipeFd, F_SETFL, flag | O_NONBLOCK);
+    else
+        flag = ::fcntl(pipeFd, F_SETFL, flag & ~O_NONBLOCK);
 }
 
 } // end namespace internal

--- a/net/PipeChannel.h
+++ b/net/PipeChannel.h
@@ -27,6 +27,7 @@ private:
     int writeFd_;
 };
 
+void SetPipeNonBlock(int sock, bool nonBlock = true);
 } // end namespace internal
 
 } // end namespace ananas


### PR DESCRIPTION

pipe用于唤醒EventLoop中的Poller，使之能够处理已放入队列中的请求；

如果pipe是阻塞的，
从写的角度来说，极端情况下，EventLoop在Execute执行过多，notifier->Notify调用次数过多，导致pipe已写入内容超出限制，会阻塞流程；从读的角度来说，由于notifer是EventLoop独享，理论上不会出现PipeChannel调用HandleReadEvent时pipe为空的情况，可以认为对读没有影响

总之，加上非阻塞能够避免极端情况下的EventLoop阻塞。

