### PR TITLE
refine logger wait and poll timeout

### DIFF
--- a/net/EventLoop.cc
+++ b/net/EventLoop.cc
@@ -204,7 +204,7 @@ bool EventLoop::Cancel(TimerId id) {
 }
 
 void EventLoop::Run() {
-    const DurationMs kDefaultPollTime(10);
+    const DurationMs kDefaultPollTime(1000);
     const DurationMs kMinPollTime(1);
 
     Register(internal::eET_Read, notifier_);


### PR DESCRIPTION
otherwise will case high cpu occupancy

日志的timeout 1s也许更合适，太大会造成回显延迟，不方便debug，太小了会导致CPU占用率太高。
poll的超时也类似，看了其他一些例子（如muduo），10s应该是个合适的值。