### PR TITLE
fix compilation error: return Future in Then callback that accepts void

### DIFF
--- a/future/Future.h
+++ b/future/Future.h
@@ -392,8 +392,7 @@ public:
                 // because func return another future: innerFuture, when innerFuture is done, nextFuture can be done
                 decltype(f(res.template Get<Args>()...)) innerFuture;
                 if (res.HasException()) {
-                    // Failed if Args... is void
-                    innerFuture = f(typename TryWrapper<typename std::decay<Args...>::type>::Type(res.Exception()));
+                    innerFuture = f(typename TryWrapper<typename std::decay<Args...>::type>::Type(res.Exception()).template Get<Args>()...);
                 } else {
                     innerFuture = f(res.template Get<Args>()...);
                 }
@@ -456,8 +455,7 @@ public:
                     // because func return another future: innerFuture, when innerFuture is done, nextFuture can be done
                     decltype(func(t.template Get<Args>()...)) innerFuture;
                     if (t.HasException()) {
-                        // Failed if Args... is void
-                        innerFuture = func(typename TryWrapper<typename std::decay<Args...>::type>::Type(t.Exception()));
+                        innerFuture = f(typename TryWrapper<typename std::decay<Args...>::type>::Type(res.Exception()).template Get<Args>()...);
                     } else {
                         innerFuture = func(t.template Get<Args>()...);
                     }

--- a/future/Future.h
+++ b/future/Future.h
@@ -455,7 +455,7 @@ public:
                     // because func return another future: innerFuture, when innerFuture is done, nextFuture can be done
                     decltype(func(t.template Get<Args>()...)) innerFuture;
                     if (t.HasException()) {
-                        innerFuture = f(typename TryWrapper<typename std::decay<Args...>::type>::Type(res.Exception()).template Get<Args>()...);
+                        innerFuture = func(typename TryWrapper<typename std::decay<Args...>::type>::Type(t.Exception()).template Get<Args>()...);
                     } else {
                         innerFuture = func(t.template Get<Args>()...);
                     }


### PR DESCRIPTION
# Summary
return Future in Then callback that accepts void causes compilation error
# Sample Code
```c++
auto& app = Application::Instance();
auto& loop = *app.BaseLoop();    
loop.Execute([]{})
.Then([&loop] { 
    return loop.Execute([]{ std::cout << "switching... " << std::endl; }); 
});
```
# Compliation Error
```c++
/mnt/d/workspace/ananas/../ananas/future/Future.h: In instantiation of ‘typename std::enable_if<typename R::IsReturnsFuture::value, typename R::ReturnFutureType>::type ananas::Future<T>::_ThenImpl(ananas::Scheduler*, F&&, ananas::internal::ResultOfWrapper<F, Args ...>) [with F = main(int, char**)::<lambda()>; R = ananas::internal::CallableResult<main(int, char**)::<lambda()>, void>; Args = {}; T = void; typename std::enable_if<typename R::IsReturnsFuture::value, typename R::ReturnFutureType>::type = ananas::Future<void>; typename R::ReturnFutureType = ananas::Future<void>; typename R::IsReturnsFuture = ananas::internal::IsFuture<ananas::Future<void> >]’:
/mnt/d/workspace/ananas/../ananas/future/Future.h:286:31:   required from ‘typename R::ReturnFutureType ananas::Future<T>::Then(F&&) [with F = main(int, char**)::<lambda()>; R = ananas::internal::CallableResult<main(int, char**)::<lambda()>, void>; T = void; typename R::ReturnFutureType = ananas::Future<void>]’
/mnt/d/workspace/ananas/tests/test_future/FutureDemo3.cc:26:10:   required from here
/mnt/d/workspace/ananas/../ananas/future/Future.h:439:98: error: wrong number of template arguments (0, should be 1)
  439 |                         innerFuture = f(typename TryWrapper<typename std::decay<Args...>::type>::Type(res.Exception()));
      |
```